### PR TITLE
Fix resetting scores in settings

### DIFF
--- a/scripts/settings.gd
+++ b/scripts/settings.gd
@@ -129,7 +129,7 @@ func _on_ok_pseudo():
     show_message("Pseudo changé !")
 
 func _on_reset_scores():
-    ScoreManager.reset() # À adapter à ta logique (voir plus bas)
+    ScoreManager.reset_local_scores()
     show_message("Scores remis à zéro !")
 
 func _on_back_pressed():


### PR DESCRIPTION
## Summary
- correct the score reset in `settings.gd`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840bbcb701c832d83e24d4e2e6c276f