### PR TITLE
Ajout du wrap horizontal du personnage

### DIFF
--- a/scripts/character_body_2d.gd
+++ b/scripts/character_body_2d.gd
@@ -70,6 +70,12 @@ func _physics_process(delta: float) -> void:
 
     move_and_slide()
 
+    var vw = get_viewport_rect().size.x
+    if global_position.x > vw:
+        global_position.x -= vw
+    elif global_position.x < 0:
+        global_position.x += vw
+
     if not anim.is_playing() and not did_rebound:
         anim.play("fly")
         update_collision_shape()


### PR DESCRIPTION
## Résumé
- le joueur se téléporte de l'autre côté de l'écran quand il sort des limites horizontales

## Tests
- `godot --version` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68418d331ae4832d95b50dbf3cf2ed3b