### PR TITLE
Ajout d'une page admin pour messages

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ LevelManager="*res://scripts/LevelManager.gd"
 ScoreManager="*res://scripts/managers/ScoreManager.gd"
 FirestoreManager="*res://scripts/managers/FirestoreManager.gd"
 SettingsManager="*res://scripts/managers/SettingsManager.gd"
+AdminMessageManager="*res://scripts/managers/AdminMessageManager.gd"
 
 [display]
 

--- a/scenes/AdminPage.tscn
+++ b/scenes/AdminPage.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/admin_page.gd" id="1"]
+
+[node name="AdminPage" type="CanvasLayer"]
+script = ExtResource("1")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -300.0
+offset_top = -200.0
+offset_right = 300.0
+offset_bottom = 200.0
+theme_override_constants/separation = 20
+alignment = 1
+
+[node name="MessageEdit" type="TextEdit" parent="VBoxContainer"]
+size_flags_vertical = 4
+
+[node name="BtnSave" type="Button" parent="VBoxContainer"]
+text = "Enregistrer"
+
+[node name="BtnBack" type="Button" parent="VBoxContainer"]
+text = "Retour"

--- a/scenes/MainMenu.tscn
+++ b/scenes/MainMenu.tscn
@@ -241,6 +241,19 @@ offset_right = 1423.0
 offset_bottom = 1422.0
 scale = Vector2(0.5, 0.5)
 texture = ExtResource("7_k04n6")
+[node name="AdminMessage" type="RichTextLabel" parent="encart"]
+anchors_preset = 8
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = 20.0
+offset_right = -20.0
+offset_bottom = -20.0
+bbcode_enabled = true
+visible = false
+
 
 [node name="LabelPseudo" type="Label" parent="."]
 anchors_preset = 8

--- a/scenes/settings.tscn
+++ b/scenes/settings.tscn
@@ -169,6 +169,11 @@ layout_mode = 2
 size_flags_horizontal = 4
 text = "Réinitialiser les scores en local "
 
+[node name="BtnAdmin" type="Button" parent="VBoxContainer"]
+visible = false
+layout_mode = 2
+text = "ADMIN"
+
 [node name="BtnBack" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 text = "BACK"

--- a/scripts/admin_page.gd
+++ b/scripts/admin_page.gd
@@ -1,0 +1,17 @@
+extends CanvasLayer
+
+@onready var message_edit = $VBoxContainer/MessageEdit
+@onready var btn_save = $VBoxContainer/BtnSave
+@onready var btn_back = $VBoxContainer/BtnBack
+
+func _ready():
+    message_edit.text = AdminMessageManager.load_message()
+    btn_save.pressed.connect(_on_save_pressed)
+    btn_back.pressed.connect(_on_back_pressed)
+
+func _on_save_pressed():
+    AdminMessageManager.save_message(message_edit.text)
+    print("Message enregistr\u00e9")
+
+func _on_back_pressed():
+    get_tree().change_scene_to_file("res://scenes/settings.tscn")

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -6,6 +6,7 @@ extends CanvasLayer
 
 @onready var pseudo_lineedit = $VBoxContainer/PseudoLineEdit
 @onready var label_pseudo = $LabelPseudo  # Adapter le chemin si besoin (en général à la racine du MainMenu)
+@onready var admin_message_label = $encart/AdminMessage
 
 func _ready():
     var saved_pseudo = ScoreManager.load_pseudo()
@@ -28,6 +29,10 @@ func _ready():
     $VBoxContainer/LeaderboardButton.pressed.connect(_on_Leaderboard_pressed)
     $VBoxContainer/SettingsButton.pressed.connect(_on_Settings_pressed)
     $VBoxContainer/QuitButton.pressed.connect(_on_Quit_pressed)
+    var admin_msg = AdminMessageManager.load_message()
+    admin_message_label.bbcode_enabled = true
+    admin_message_label.text = admin_msg
+    admin_message_label.visible = admin_msg != ""
 
 
 

--- a/scripts/managers/AdminMessageManager.gd
+++ b/scripts/managers/AdminMessageManager.gd
@@ -1,0 +1,15 @@
+extends Node
+
+var message: String = ""
+
+func load_message() -> String:
+    var config = ConfigFile.new()
+    if config.load("user://admin_message.cfg") == OK:
+        message = str(config.get_value("admin", "message", ""))
+    return message
+
+func save_message(new_message: String) -> void:
+    message = new_message
+    var config = ConfigFile.new()
+    config.set_value("admin", "message", message)
+    config.save("user://admin_message.cfg")

--- a/scripts/settings.gd
+++ b/scripts/settings.gd
@@ -11,11 +11,13 @@ extends CanvasLayer
 @onready var btn_ok_pseudo    = $VBoxContainer/HBoxEditPseudo/BtnOkPseudo
 @onready var btn_reset     = $VBoxContainer/BtnReset
 @onready var btn_back      = $VBoxContainer/BtnBack
+@onready var btn_admin     = $VBoxContainer/BtnAdmin
 @onready var label_music_percent = $VBoxContainer/HBoxMusic/LabelMusicPercent
 @onready var label_sfx_percent   = $VBoxContainer/HBoxSFX/LabelSFXPercent
 
 var available_languages = ["Français", "English", "Español"] # Modifie selon tes besoins
 var settings_file = "user://settings.cfg"
+var admin_scene_path : String = "res://scenes/AdminPage.tscn"
 
 func _ready():
     load_settings()
@@ -26,6 +28,8 @@ func _ready():
     hbox_edit_pseudo.visible = false
     btn_modify_pseudo.pressed.connect(_on_modify_pseudo)
     btn_ok_pseudo.pressed.connect(_on_ok_pseudo)
+    var pseudo = ScoreManager.load_pseudo()
+    btn_admin.visible = pseudo.to_lower() == "admin"
 
 func load_settings():
     var config = ConfigFile.new()
@@ -71,6 +75,7 @@ func connect_signals():
     btn_ok_pseudo.pressed.connect(_on_ok_pseudo)
     btn_reset.pressed.connect(_on_reset_scores)
     btn_back.pressed.connect(_on_back_pressed)
+    btn_admin.pressed.connect(_on_admin_pressed)
 
 func _on_music_volume_changed(value):
     AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Music"), linear_to_db(value))
@@ -134,6 +139,10 @@ func _on_reset_scores():
 
 func _on_back_pressed():
     get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+
+func _on_admin_pressed():
+    if admin_scene_path != "":
+        get_tree().change_scene_to_file(admin_scene_path)
 
 func show_message(msg):
     print(msg)


### PR DESCRIPTION
## Summary
- nouvelle scene `AdminPage` avec son script pour saisir un message administrateur
- gestionnaire `AdminMessageManager` pour charger et sauvegarder ce message
- ajout d'un bouton Admin dans la scène des paramètres, visible seulement si le pseudo est `admin`
- affichage du message admin dans le menu principal
- enregistrement de ce manager dans les autoloads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e7451020832dbbc42f011b025966