### PR TITLE
Fix admin message label path

### DIFF
--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -6,7 +6,7 @@ extends CanvasLayer
 
 @onready var pseudo_lineedit = $VBoxContainer/PseudoLineEdit
 @onready var label_pseudo = $LabelPseudo  # Adapter le chemin si besoin (en général à la racine du MainMenu)
-@onready var admin_message_label = $encart/AdminMessage
+@onready var admin_message_label = $encartAdmin/AdminMessage
 
 func _ready():
     var saved_pseudo = ScoreManager.load_pseudo()


### PR DESCRIPTION
## Summary
- ajuster `admin_message_label` pour viser `encartAdmin/AdminMessage`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68420939f31c832d9c3fb7b5abf8be3d