### PR TITLE
Add Firestore admin message support

### DIFF
--- a/scripts/admin_page.gd
+++ b/scripts/admin_page.gd
@@ -6,12 +6,19 @@ extends CanvasLayer
 
 func _ready():
     message_edit.text = AdminMessageManager.load_message()
+    AdminMessageManager.fetch_message(func(msg):
+        message_edit.text = msg
+    )
     btn_save.pressed.connect(_on_save_pressed)
     btn_back.pressed.connect(_on_back_pressed)
 
 func _on_save_pressed():
-    AdminMessageManager.save_message(message_edit.text)
-    print("Message enregistr\u00e9")
+    AdminMessageManager.save_message(message_edit.text, func(success):
+        if success:
+            print("Message enregistr\u00e9")
+        else:
+            print("Erreur lors de l'enregistrement du message")
+    )
 
 func _on_back_pressed():
     get_tree().change_scene_to_file("res://scenes/settings.tscn")

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -33,6 +33,10 @@ func _ready():
     admin_message_label.bbcode_enabled = true
     admin_message_label.text = admin_msg
     admin_message_label.visible = admin_msg != ""
+    AdminMessageManager.fetch_message(func(msg):
+        admin_message_label.text = msg
+        admin_message_label.visible = msg != ""
+    )
 
 
 

--- a/scripts/managers/AdminMessageManager.gd
+++ b/scripts/managers/AdminMessageManager.gd
@@ -2,14 +2,37 @@ extends Node
 
 var message: String = ""
 
-func load_message() -> String:
+func _load_local() -> String:
     var config = ConfigFile.new()
     if config.load("user://admin_message.cfg") == OK:
-        message = str(config.get_value("admin", "message", ""))
-    return message
+        return str(config.get_value("admin", "message", ""))
+    return ""
 
-func save_message(new_message: String) -> void:
-    message = new_message
+func _save_local():
     var config = ConfigFile.new()
     config.set_value("admin", "message", message)
     config.save("user://admin_message.cfg")
+
+func load_message() -> String:
+    message = _load_local()
+    return message
+
+func fetch_message(callback):
+    FirestoreManager.fetch_admin_message(func(msg):
+        if msg == null or msg == "":
+            message = _load_local()
+        else:
+            message = msg
+            _save_local()
+        if callback:
+            callback.call(message)
+    )
+
+func save_message(new_message: String, callback = null) -> void:
+    message = new_message
+    FirestoreManager.save_admin_message(message, func(success):
+        if success:
+            _save_local()
+        if callback:
+            callback.call(success)
+    )


### PR DESCRIPTION
## Summary
- connect admin messages to Firebase Firestore
- cache message locally and fallback if offline
- show message in MainMenu and allow edition from AdminPage

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421079a744832db60a551b51eb504d