### PR TITLE
Log HTTP details when fetching admin message

### DIFF
--- a/scripts/managers/FirestoreManager.gd
+++ b/scripts/managers/FirestoreManager.gd
@@ -172,8 +172,12 @@ func fetch_admin_message(callback):
     get_tree().root.add_child(http)
 
     http.request_completed.connect(func(result, code, headers, body):
+        var body_text = body.get_string_from_utf8()
+        print("fetch_admin_message HTTP code:", code)
+        print("fetch_admin_message body:", body_text)
         if result != HTTPRequest.RESULT_SUCCESS or code != 200:
             push_error("Erreur HTTP: %d" % code)
+            push_error(body_text)
             if callback:
                 callback.call(null)
             http.queue_free()


### PR DESCRIPTION
## Summary
- print the HTTP status code and body when fetching the admin message
- report the HTTP code and body via `push_error` if the request fails

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684229360e30832dad15d502b51b2b49