### PR TITLE
Affiche les messages chargés et reçus

### DIFF
--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -34,6 +34,7 @@ func _ready():
     admin_message_label.text = admin_msg
     admin_message_label.visible = admin_msg != ""
     AdminMessageManager.fetch_message(func(msg):
+        print("Message re\u00e7u :", msg)
         admin_message_label.text = msg
         admin_message_label.visible = msg != ""
     )

--- a/scripts/managers/AdminMessageManager.gd
+++ b/scripts/managers/AdminMessageManager.gd
@@ -15,6 +15,7 @@ func _save_local():
 
 func load_message() -> String:
     message = _load_local()
+    print("Message charg\u00e9 :", message)
     return message
 
 func fetch_message(callback):


### PR DESCRIPTION
## Summary
- log le message chargé par `AdminMessageManager.load_message`
- log le message récupéré avant de changer la visibilité dans `MainMenu`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684229452380832db2692b723ddd3efd