### PR TITLE
Fix admin message box visibility

### DIFF
--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -7,6 +7,7 @@ extends CanvasLayer
 @onready var pseudo_lineedit = $VBoxContainer/PseudoLineEdit
 @onready var label_pseudo = $LabelPseudo  # Adapter le chemin si besoin (en général à la racine du MainMenu)
 @onready var admin_message_label = $encartAdmin/AdminMessage
+@onready var admin_message_box   = $encartAdmin
 
 func _ready():
     var saved_pseudo = ScoreManager.load_pseudo()
@@ -32,10 +33,18 @@ func _ready():
     var admin_msg = AdminMessageManager.load_message()
     admin_message_label.bbcode_enabled = true
     admin_message_label.text = admin_msg
-    admin_message_label.visible = admin_msg != ""
+    var has_msg = admin_msg != ""
+    admin_message_label.visible = has_msg
+    admin_message_box.visible = has_msg
+    if has_msg:
+        print("Encart admin visible")
     AdminMessageManager.fetch_message(func(msg):
         admin_message_label.text = msg
-        admin_message_label.visible = msg != ""
+        var show = msg != ""
+        admin_message_label.visible = show
+        admin_message_box.visible = show
+        if show:
+            print("Encart admin visible")
     )
 
 


### PR DESCRIPTION
## Summary
- handle new `admin_message_box` node in MainMenu
- show admin message box when a non-empty message exists
- log when the box becomes visible

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684229531b94832db8db042fe1783b28