### PR TITLE
Ajout d'un thème pour la boîte de mise à jour

### DIFF
--- a/assets/themes/update_dialog_theme.tres
+++ b/assets/themes/update_dialog_theme.tres
@@ -4,4 +4,4 @@
 
 [resource]
 default_font = ExtResource(1)
-default_font_size = 24
+default_font_size = 26

--- a/assets/themes/update_dialog_theme.tres
+++ b/assets/themes/update_dialog_theme.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Theme" format=3]
+
+[ext_resource path="res://assets/fonts/LuckiestGuy-Regular.ttf" type="FontFile" id="1"]
+
+[resource]
+default_font = ExtResource(1)
+default_font_size = 24

--- a/scripts/managers/VersionManager.gd
+++ b/scripts/managers/VersionManager.gd
@@ -3,6 +3,7 @@ extends Node
 const CURRENT_VERSION := "1.0.1"
 const VERSION_URL := "https://gist.githubusercontent.com/MSJ2025/4d20c7a04314d0a760b19bc41ae59c37/raw/c57b2d11e31f2efd827c4cf3ba27ad0fa6fbbcb9/version.txt"
 const DOWNLOAD_URL := "https://example.com/download"
+const UPDATE_THEME := preload("res://assets/themes/update_dialog_theme.tres")
 
 func check_for_update() -> void:
     var http := HTTPRequest.new()
@@ -23,12 +24,15 @@ func check_for_update() -> void:
 
         if latest_version != CURRENT_VERSION:
             print("Nouvelle version détectée, affichage du dialogue")
-            var dialog := AcceptDialog.new()
+            var dialog := ConfirmationDialog.new()
             dialog.title = "Mise à jour disponible"
-            dialog.dialog_text = "Une nouvelle version (" + latest_version + ") est disponible."
+            dialog.dialog_text = "Une nouvelle version (" + latest_version + ") est disponible.\n\nTélécharger : " + DOWNLOAD_URL
             dialog.ok_button_text = "Télécharger"
+            dialog.cancel_button_text = "Plus tard"
+            dialog.theme = UPDATE_THEME
+            dialog.min_size = Vector2(480, 220)
             dialog.confirmed.connect(Callable(self, "_on_update_confirmed"))
-            get_tree().root.call_deferred("add_child", dialog)
+            get_tree().root.add_child(dialog)
             dialog.popup_centered()
         else:
             print("Version à jour, pas besoin d'afficher le dialogue")
@@ -37,6 +41,7 @@ func check_for_update() -> void:
     var error = http.request(VERSION_URL)
     if error != OK:
         push_error("Impossible d'envoyer la requête HTTP : %d" % error)
+        http.queue_free()
 
 func _on_update_confirmed() -> void:
     OS.shell_open(DOWNLOAD_URL)

--- a/scripts/managers/VersionManager.gd
+++ b/scripts/managers/VersionManager.gd
@@ -30,7 +30,7 @@ func check_for_update() -> void:
             dialog.ok_button_text = "Télécharger"
             dialog.cancel_button_text = "Plus tard"
             dialog.theme = UPDATE_THEME
-            dialog.min_size = Vector2(480, 220)
+            dialog.min_size = Vector2(500, 240)
             dialog.confirmed.connect(Callable(self, "_on_update_confirmed"))
             get_tree().root.add_child(dialog)
             dialog.popup_centered()


### PR DESCRIPTION
## Summary
- crée un thème `update_dialog_theme.tres`
- applique ce thème dans `VersionManager.gd` et agrandit la fenêtre

## Testing
- `godot --version` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6842ed657d28832d9fe3c8294093514f