### PR TITLE
Fix audio settings and best score

### DIFF
--- a/scripts/game_over_layer.gd
+++ b/scripts/game_over_layer.gd
@@ -33,8 +33,8 @@ func _process(delta):
         label_score.text = "Score : %d" % displayed_score
     else:
         set_process(false)
-        # Afficher le meilleur score
-        var best = final_score # ou lire le local record si tu veux
+        # Afficher le meilleur score enregistré localement
+        var best = ScoreManager.get_best_score()
         label_best_score.text = "🏆 Record : %d" % best
 
         # ACTIVER LES BOUTONS ici si besoin

--- a/scripts/managers/ScoreManager.gd
+++ b/scripts/managers/ScoreManager.gd
@@ -3,6 +3,9 @@ extends Node
 
 var leaderboard : Array = []
 
+func _ready() -> void:
+    load()
+
 func load_pseudo() -> String:
     var config = ConfigFile.new()
     var err = config.load("user://user_settings.cfg")

--- a/scripts/settings.gd
+++ b/scripts/settings.gd
@@ -31,8 +31,8 @@ func _ready():
 func load_settings():
     var config = ConfigFile.new()
     if config.load(settings_file) == OK:
-        slider_music.value = float(config.get_value("audio", "volume_music", 1.0))
-        slider_sfx.value   = float(config.get_value("audio", "volume_sfx", 1.0))
+        slider_music.value = float(config.get_value("audio", "music_volume", 1.0))
+        slider_sfx.value   = float(config.get_value("audio", "sfx_volume", 1.0))
         check_vibro.button_pressed = bool(config.get_value("vibration", "enabled", true))
         var lang = str(config.get_value("ui", "language", "Français"))
         option_lang.selected = max(available_languages.find(lang), 0)
@@ -44,8 +44,8 @@ func load_settings():
 
 func save_settings():
     var config = ConfigFile.new()
-    config.set_value("audio", "volume_music", slider_music.value)
-    config.set_value("audio", "volume_sfx", slider_sfx.value)
+    config.set_value("audio", "music_volume", slider_music.value)
+    config.set_value("audio", "sfx_volume", slider_sfx.value)
     config.set_value("vibration", "enabled", check_vibro.button_pressed)
     config.set_value("ui", "language", available_languages[option_lang.selected])
     config.save(settings_file)
@@ -60,8 +60,8 @@ func setup_ui():
     label_pseudo.text = pseudo
     hbox_edit_pseudo.visible = false
     # Applique volume audio dès le départ
-    AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Music"), linear_to_db(slider_music.value))
-    AudioServer.set_bus_volume_db(AudioServer.get_bus_index("SFX"), linear_to_db(slider_sfx.value))
+    SettingsManager.set_music_volume(slider_music.value)
+    SettingsManager.set_sfx_volume(slider_sfx.value)
 
 func connect_signals():
     slider_music.value_changed.connect(_on_music_volume_changed)
@@ -74,17 +74,17 @@ func connect_signals():
     btn_back.pressed.connect(_on_back_pressed)
 
 func _on_music_volume_changed(value):
-    AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Music"), linear_to_db(value))
+    SettingsManager.set_music_volume(value)
     label_music_percent.text = str(round(value * 100)) + "%"
     save_settings()
 
 func _on_sfx_volume_changed(value):
-    AudioServer.set_bus_volume_db(AudioServer.get_bus_index("SFX"), linear_to_db(value))
+    SettingsManager.set_sfx_volume(value)
     label_sfx_percent.text = str(round(value * 100)) + "%"
     save_settings()
 
 func _on_vibro_toggled(pressed):
-    # Appelle ici ton gestionnaire de vibration si tu veux tester
+    SettingsManager.set_vibration(pressed)
     save_settings()
 
 func _on_lang_selected(idx):


### PR DESCRIPTION
## Summary
- load leaderboard on startup so best score persists
- use SettingsManager for volume/vibration and unify setting keys
- show stored best score on Game Over screen

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436a29909c832d809cf8cc9b8b1c7b