### PR TITLE
Ajout de la configuration des bus audio

### DIFF
--- a/default_bus_layout.tres
+++ b/default_bus_layout.tres
@@ -1,0 +1,23 @@
+[gd_resource type="AudioBusLayout" format=3]
+
+[resource]
+bus/0/name = "Master"
+bus/0/solo = false
+bus/0/mute = false
+bus/0/bypass_effects = false
+bus/0/volume_db = 0.0
+bus/0/send = ""
+
+bus/1/name = "Music"
+bus/1/solo = false
+bus/1/mute = false
+bus/1/bypass_effects = false
+bus/1/volume_db = 0.0
+bus/1/send = "Master"
+
+bus/2/name = "SFX"
+bus/2/solo = false
+bus/2/mute = false
+bus/2/bypass_effects = false
+bus/2/volume_db = 0.0
+bus/2/send = "Master"

--- a/project.godot
+++ b/project.godot
@@ -47,3 +47,7 @@ ui_jump={
 textures/canvas_textures/default_texture_filter=0
 renderer/rendering_method="mobile"
 textures/vram_compression/import_etc2_astc=true
+
+[audio]
+enable_audio_bus_layout=true
+audio_bus_layout="res://default_bus_layout.tres"

--- a/scenes/Game.tscn
+++ b/scenes/Game.tscn
@@ -81,28 +81,35 @@ score_line_scene = ExtResource("7_m3jgn")
 
 [node name="BananaPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("8_l4tja")
+bus = "SFX"
 
 [node name="BurpPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("9_yygk8")
+bus = "SFX"
 
 [node name="BGMPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("8_b26ab")
 volume_db = -11.949
 autoplay = true
 parameters/looping = true
+bus = "Music"
 
 [node name="PeanutPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("9_wrouo")
+bus = "SFX"
 
 [node name="MagnetPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("11_4wvjy")
+bus = "SFX"
 
 [node name="LevelUpPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("11_fat3d")
+bus = "SFX"
 
 [node name="Jump" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("14_y0he4")
 volume_db = 10.271
+bus = "SFX"
 
 [node name="Parallax2D" type="ParallaxBackground" parent="."]
 
@@ -217,6 +224,7 @@ scale = Vector2(1, 1)
 
 [node name="JumpPlayer" type="AudioStreamPlayer" parent="Player"]
 stream = ExtResource("14_y0he4")
+bus = "SFX"
 
 [node name="LevelLine" type="ColorRect" parent="."]
 offset_left = -320.0

--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -129,3 +129,4 @@ shape = SubResource("RectangleShape2D_5o1au")
 
 [node name="JumpSound" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource("3_c4cbx")
+bus = "SFX"


### PR DESCRIPTION
## Résumé
- création d'un fichier `default_bus_layout.tres` définissant les bus `Music` et `SFX`
- activation de la mise en page des bus audio dans `project.godot`
- assignation du bus adéquat pour tous les `AudioStreamPlayer`

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843f6ed9b34832da0fbb29804249962