### PR TITLE
Recharge et sauvegarde des scores

### DIFF
--- a/scripts/game_over_layer.gd
+++ b/scripts/game_over_layer.gd
@@ -14,6 +14,8 @@ var displayed_score: int = 0
 var anim_speed     : int = 600   # points par seconde
 
 func show_results(height, bananas):
+    # Recharge le tableau des scores pour disposer de la dernière version
+    ScoreManager.load()
     final_meters = int(height)
     final_bananas = int(bananas)
     final_score = final_meters * 0.5 + final_bananas * 5

--- a/scripts/managers/ScoreManager.gd
+++ b/scripts/managers/ScoreManager.gd
@@ -29,7 +29,11 @@ func save():
         var key = "score_%d" % i
         config.set_value("scores", key + "_username", leaderboard[i]["pseudo"])
         config.set_value("scores", key + "_value", int(leaderboard[i]["score"]))
-    config.save("user://leaderboard.cfg")
+    var err = config.save("user://leaderboard.cfg")
+    if err != OK:
+        push_error("Impossible d'enregistrer user://leaderboard.cfg : %s" % err)
+    elif not FileAccess.file_exists("user://leaderboard.cfg"):
+        push_error("Fichier user://leaderboard.cfg non trouvé après sauvegarde")
 
 func load():
     leaderboard.clear()

--- a/scripts/tests/test_best_score.gd
+++ b/scripts/tests/test_best_score.gd
@@ -1,0 +1,13 @@
+extends Node
+
+func _ready():
+    var manager = preload("../managers/ScoreManager.gd").new()
+    add_child(manager)
+    manager.reset() # clear any existing scores
+    manager.add_score("A", 10)
+    manager.add_score("B", 40)
+    manager.add_score("C", 30)
+    print("Best score after three games:", manager.get_best_score())
+    manager.add_score("D", 50)
+    print("Best score after adding 50:", manager.get_best_score())
+    get_tree().quit()


### PR DESCRIPTION
## Summary
- recharge le tableau des scores avant l'affichage des résultats
- vérifie l'écriture du fichier `user://leaderboard.cfg`
- ajoute un petit script de test pour le meilleur score

## Testing
- `godot3-server --no-window --path /tmp/godot3_project -s /workspace/WackyMonkey/scripts/tests/test_best_score.gd` *(échoue : Parse Error)*

------
https://chatgpt.com/codex/tasks/task_e_6843f7011e04832dad95c57957bd8f03