### PR TITLE
Recharge et sauvegarde des scores

### DIFF
--- a/scripts/game_over_layer.gd
+++ b/scripts/game_over_layer.gd
@@ -14,6 +14,8 @@ var displayed_score: int = 0
 var anim_speed     : int = 600   # points par seconde
 
 func show_results(height, bananas):
+    # Recharge le tableau des scores pour disposer de la dernière version
+    ScoreManager.load()
     final_meters = int(height)
     final_bananas = int(bananas)
     final_score = final_meters * 0.5 + final_bananas * 5

--- a/scripts/managers/ScoreManager.gd
+++ b/scripts/managers/ScoreManager.gd
@@ -16,7 +16,7 @@ func load_pseudo() -> String:
 func add_score(pseudo: String, score: int) -> void:
     leaderboard.append({"pseudo": pseudo, "score": int(score)})
     # Toujours trier en mémoire, du plus haut au plus bas
-    leaderboard.sort_custom(func(a, b): return int(b["score"]) - int(a["score"]))
+    leaderboard.sort_custom(func(a, b): return int(a["score"]) > int(b["score"]))
     if leaderboard.size() > 10:
         leaderboard = leaderboard.slice(0, 10)
     save()
@@ -24,12 +24,16 @@ func add_score(pseudo: String, score: int) -> void:
 func save():
     var config = ConfigFile.new()
     # Toujours sauver les scores du plus haut au plus bas
-    leaderboard.sort_custom(func(a, b): return int(b["score"]) - int(a["score"]))
+    leaderboard.sort_custom(func(a, b): return int(a["score"]) > int(b["score"]))
     for i in range(leaderboard.size()):
         var key = "score_%d" % i
         config.set_value("scores", key + "_username", leaderboard[i]["pseudo"])
         config.set_value("scores", key + "_value", int(leaderboard[i]["score"]))
-    config.save("user://leaderboard.cfg")
+    var err = config.save("user://leaderboard.cfg")
+    if err != OK:
+        push_error("Impossible d'enregistrer user://leaderboard.cfg : %s" % err)
+    elif not FileAccess.file_exists("user://leaderboard.cfg"):
+        push_error("Fichier user://leaderboard.cfg non trouvé après sauvegarde")
 
 func load():
     leaderboard.clear()
@@ -43,12 +47,12 @@ func load():
             if pseudo != null and score != null:
                 leaderboard.append({"pseudo": pseudo, "score": int(score)})
     # Toujours trier après chargement
-    leaderboard.sort_custom(func(a, b): return int(b["score"]) - int(a["score"]))
+    leaderboard.sort_custom(func(a, b): return int(a["score"]) > int(b["score"]))
 
 func get_top_scores() -> Array:
     # Renvoie une copie triée à l’affichage
     var copy = leaderboard.duplicate()
-    copy.sort_custom(func(a, b): return int(b["score"]) - int(a["score"]))
+    copy.sort_custom(func(a, b): return int(a["score"]) > int(b["score"]))
     return copy
     
 func save_pseudo(pseudo: String) -> void:
@@ -85,7 +89,7 @@ func reset() -> void:
 func get_best_score() -> int:
     if leaderboard.is_empty():
         return 0
-    leaderboard.sort_custom(func(a, b): return int(b["score"]) - int(a["score"]))
+    leaderboard.sort_custom(func(a, b): return int(a["score"]) > int(b["score"]))
     return leaderboard[0]["score"]
     
 func get_best_height():

--- a/scripts/tests/test_best_score.gd
+++ b/scripts/tests/test_best_score.gd
@@ -1,0 +1,13 @@
+extends Node
+
+func _ready():
+    var manager = preload("../managers/ScoreManager.gd").new()
+    add_child(manager)
+    manager.reset() # clear any existing scores
+    manager.add_score("A", 10)
+    manager.add_score("B", 40)
+    manager.add_score("C", 30)
+    print("Best score after three games:", manager.get_best_score())
+    manager.add_score("D", 50)
+    print("Best score after adding 50:", manager.get_best_score())
+    get_tree().quit()


### PR DESCRIPTION
## Summary
- recharge le tableau des scores avant l'affichage des résultats
- vérifie l'écriture du fichier `user://leaderboard.cfg`
- ajoute un petit script de test pour le meilleur score
- corrige le tri du classement

## Testing
- `godot3-server --no-window --path . -s scripts/tests/test_best_score.gd` *(échoue : Can't open project / parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843f7011e04832dad95c57957bd8f03