### PR TITLE
Ajout du mot-clé tool pour le plugin Firebase

### DIFF
--- a/addons/godot-firebase/plugin.gd
+++ b/addons/godot-firebase/plugin.gd
@@ -1,3 +1,4 @@
+tool
 extends EditorPlugin
 
 func _enter_tree() -> void:


### PR DESCRIPTION
## Summary
- active le mode `tool` dans le plugin Firebase pour qu'il soit chargé dans l'éditeur

## Testing
- `godot4 --headless --check-only -s scripts/tests/test_best_score.gd`

------
https://chatgpt.com/codex/tasks/task_e_684444ea3a68832d8291bfca90758644